### PR TITLE
now using strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Stream = require('stream')
 const bugsnag = require('bugsnag')
 


### PR DESCRIPTION
I'm getting an error when importing this in a Node env less than the LTS and current stable.

I'm currently working in AWS Lambda which requires Node 4.3.0 so changing node versions isn't possible. Per the README lower versions should be supported.

Easy fix is to add `'use strict'`.

```
/Users/austenlacy/work/citadel/shared/lumberjack/node_modules/bunyan-bugsnag/index.js:68
    for (let i = 0; i < systemInfo.length; ++i) {
         ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/austenlacy/work/citadel/shared/lumberjack/test/lumberjack.js:8:29)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at /Users/austenlacy/work/citadel/node_modules/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/austenlacy/work/citadel/node_modules/mocha/lib/mocha.js:219:14)
    at Mocha.run (/Users/austenlacy/work/citadel/node_modules/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/Users/austenlacy/work/citadel/node_modules/mocha/bin/_mocha:459:18)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:442:10)
    at startup (node.js:136:18)
    at node.js:966:3
```