### PR TITLE
add bugsnag option to override the bugsnag library imported by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ bugsnagStream({
   systemInfo: ['name', 'hostname', 'pid', 'req_id', 'level', 'time', 'v'],
   warningLevel: 'warn',
   errorLevel: 'error',
+  bugsnag: require('bugsnag')
 })
 ```
 
@@ -76,6 +77,17 @@ bugsnag.notify(error, {
 ```
 
 This will create `system` and `info` tabs in the Bugsnag report providing this information.
+
+Passing a registered bugsnag instance as an option will override the bugsnag instance that is imported from the node library.
+You can register the bugsnag library before you create the `bugsnagStream`:
+
+```javascript
+const bugsnag = require('bugsnag')
+bugsnag.register('yourbugsnagkey')
+
+bugsnagStream({ bugsnag })
+```
+
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Stream = require('stream')
-let bugsnag = require('bugsnag')
 
 const levelFromName = {
   trace: 10,
@@ -18,9 +17,8 @@ function bugsnagLogStream(options) {
     systemInfo: ['name', 'hostname', 'pid', 'req_id', 'level', 'time', 'v'],
     warningLevel: 40,
     errorLevel: 50,
+    bugsnag: require('bugsnag')
   })
-
-  bugsnag = selectBugsnag(options)
 
   return new Stream.Writable({
     objectMode: true,
@@ -34,18 +32,11 @@ function bugsnagLogStream(options) {
       const optionsMap = splitSystemAndInfo(data)
       optionsMap.severity = selectSeverity(data.level)
 
-      bugsnag.notify(error, optionsMap)
+      options.bugsnag.notify(error, optionsMap)
 
       return true
     },
   })
-
-  function selectBugsnag(opts) {
-    if (opts.bugsnag) {
-      return opts.bugsnag
-    }
-    return bugsnag
-  }
 
   function normalizeLevels(opts, defaults) {
     opts = Object.assign(defaults, opts)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Stream = require('stream')
-const bugsnag = require('bugsnag')
+let bugsnag = require('bugsnag')
 
 const levelFromName = {
   trace: 10,
@@ -19,6 +19,8 @@ function bugsnagLogStream(options) {
     warningLevel: 40,
     errorLevel: 50,
   })
+
+  bugsnag = selectBugsnag(options)
 
   return new Stream.Writable({
     objectMode: true,
@@ -38,6 +40,12 @@ function bugsnagLogStream(options) {
     },
   })
 
+  function selectBugsnag(opts) {
+    if (opts.bugsnag) {
+      return opts.bugsnag
+    }
+    return bugsnag
+  }
 
   function normalizeLevels(opts, defaults) {
     opts = Object.assign(defaults, opts)


### PR DESCRIPTION
## Overview
From my investigation and attempt to integrate this package into our bunyan set up it appeared that importing bugsnag via `require('bugsnag')` would not retain any previous bugsnag registration. 

As a result this pr will allow for a bugsnag instance that is already registered to be passed as an option.
